### PR TITLE
✨ [#5] resilience4j 회복 탄력성 갖추기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // spring cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+
+    implementation 'io.github.resilience4j:resilience4j-all'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/ecommerceorder/api/service/wishlist/WishlistServiceImpl.java
+++ b/src/main/java/com/ecommerceorder/api/service/wishlist/WishlistServiceImpl.java
@@ -17,7 +17,7 @@ import com.ecommerceorder.domain.wishlist.repository.WishlistItemRepository;
 import com.ecommerceorder.domain.wishlist.repository.WishlistRepository;
 import com.ecommerceorder.global.exception.CustomException;
 import com.ecommerceorder.global.exception.ExceptionCode;
-import com.ecommerceorder.global.feign.UserFeignClient;
+import com.ecommerceorder.global.feign.user.service.UserFeignService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -32,7 +32,7 @@ public class WishlistServiceImpl implements WishlistService{
   private final WishlistRepository wishlistRepository;
   private final WishlistItemRepository wishlistItemRepository;
   private final ProductOptionRepository productOptionRepository;
-  private final UserFeignClient userFeignClient;
+  private final UserFeignService userFeignService;
 
   @Override
   @Transactional
@@ -71,7 +71,7 @@ public class WishlistServiceImpl implements WishlistService{
             memberId, productOptions.getFirst().getProduct().getId())
         .orElseGet(() -> {
           // Member 및 Product 조회
-          if(!userFeignClient.existsMemberId(memberId)){
+          if(!userFeignService.existsMemberId(memberId)){
             throw CustomException.from(ExceptionCode.USER_NOT_FOUND);
           }
 

--- a/src/main/java/com/ecommerceorder/global/config/CircuitBreakerConfig.java
+++ b/src/main/java/com/ecommerceorder/global/config/CircuitBreakerConfig.java
@@ -1,0 +1,47 @@
+package com.ecommerceorder.global.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker.EventPublisher;
+import io.github.resilience4j.core.registry.EntryAddedEvent;
+import io.github.resilience4j.core.registry.EntryRemovedEvent;
+import io.github.resilience4j.core.registry.EntryReplacedEvent;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Slf4j
+public class CircuitBreakerConfig {
+  @Bean
+  public RegistryEventConsumer<CircuitBreaker> myRegistryEventConsumer() {
+
+    return new RegistryEventConsumer<CircuitBreaker>() {
+      @Override
+      public void onEntryAddedEvent(EntryAddedEvent<CircuitBreaker> entryAddedEvent) {
+        log.info("RegistryEventConsumer.onEntryAddedEvent");
+
+        EventPublisher eventPublisher = entryAddedEvent.getAddedEntry().getEventPublisher();
+
+        eventPublisher.onEvent(event -> log.info("onEvent {}", event));
+        eventPublisher.onSuccess(event -> log.info("onSuccess {}", event));
+        eventPublisher.onCallNotPermitted(event -> log.info("onCallNotPermitted {}", event));
+        eventPublisher.onError(event -> log.info("onError {}", event));
+        eventPublisher.onIgnoredError(event -> log.info("onIgnoredError {}", event));
+        eventPublisher.onStateTransition(event -> log.info("onStateTransition {}", event));
+        eventPublisher.onSlowCallRateExceeded(event -> log.info("onSlowCallRateExceeded {}", event));
+        eventPublisher.onFailureRateExceeded(event -> log.info("onFailureRateExceeded {}", event));
+      }
+
+      @Override
+      public void onEntryRemovedEvent(EntryRemovedEvent<CircuitBreaker> entryRemoveEvent) {
+        log.info("RegistryEventConsumer.onEntryRemovedEvent");
+      }
+
+      @Override
+      public void onEntryReplacedEvent(EntryReplacedEvent<CircuitBreaker> entryReplacedEvent) {
+        log.info("RegistryEventConsumer.onEntryReplacedEvent");
+      }
+    };
+  }
+}

--- a/src/main/java/com/ecommerceorder/global/exception/ExceptionCode.java
+++ b/src/main/java/com/ecommerceorder/global/exception/ExceptionCode.java
@@ -3,6 +3,7 @@ package com.ecommerceorder.global.exception;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,10 @@ public enum ExceptionCode {
   PRODUCT_OPTION_NOT_FOUND(NOT_FOUND, "상품 옵션 개체를 찾지 못했습니다."),
   WISHLIST_ITEM_NOT_FOUND(NOT_FOUND, "위시리스트 항목 개체를 찾지 못했습니다."),
   ORDER_NOT_FOUND(NOT_FOUND, "주문 개체를 찾지 못했습니다."),
+
+
+  USER_SERVICE_UNAVAILABLE(SERVICE_UNAVAILABLE, "유저 서비스 사용에 실패했습니다."),
+  PRODUCT_SERVICE_UNAVAILABLE(SERVICE_UNAVAILABLE, "제품 서비스 사용에 실패했습니다."),
 
   ;
   private final HttpStatus status;

--- a/src/main/java/com/ecommerceorder/global/feign/product/ProductFeignClient.java
+++ b/src/main/java/com/ecommerceorder/global/feign/product/ProductFeignClient.java
@@ -2,9 +2,9 @@
  * @Date : 2024. 09. 06.
  * @author : jieun(je-pa)
  */
-package com.ecommerceorder.global.feign;
+package com.ecommerceorder.global.feign.product;
 
-import com.ecommerceorder.global.feign.dto.UpdateQuantityByProductOptionsDto;
+import com.ecommerceorder.global.feign.product.dto.UpdateQuantityByProductOptionsDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/com/ecommerceorder/global/feign/product/dto/UpdateQuantityByProductOptionsDto.java
+++ b/src/main/java/com/ecommerceorder/global/feign/product/dto/UpdateQuantityByProductOptionsDto.java
@@ -2,7 +2,7 @@
  * @Date : 2024. 08. 28.
  * @author : jieun(je-pa)
  */
-package com.ecommerceorder.global.feign.dto;
+package com.ecommerceorder.global.feign.product.dto;
 
 import com.ecommerceorder.domain.order.entity.OrderItem;
 import java.util.Collection;

--- a/src/main/java/com/ecommerceorder/global/feign/product/service/ProductFeignService.java
+++ b/src/main/java/com/ecommerceorder/global/feign/product/service/ProductFeignService.java
@@ -1,0 +1,7 @@
+package com.ecommerceorder.global.feign.product.service;
+
+import com.ecommerceorder.global.feign.product.dto.UpdateQuantityByProductOptionsDto;
+
+public interface ProductFeignService {
+  void updateProductStock(UpdateQuantityByProductOptionsDto dto);
+}

--- a/src/main/java/com/ecommerceorder/global/feign/product/service/ProductFeignServiceImpl.java
+++ b/src/main/java/com/ecommerceorder/global/feign/product/service/ProductFeignServiceImpl.java
@@ -1,0 +1,39 @@
+package com.ecommerceorder.global.feign.product.service;
+
+import com.ecommerceorder.global.exception.CustomException;
+import com.ecommerceorder.global.exception.ExceptionCode;
+import com.ecommerceorder.global.feign.product.ProductFeignClient;
+import com.ecommerceorder.global.feign.product.dto.UpdateQuantityByProductOptionsDto;
+import com.ecommerceorder.global.feign.product.dto.UpdateQuantityByProductOptionsDto.ProductOptionInfo;
+import feign.FeignException.ServiceUnavailable;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ProductFeignServiceImpl implements ProductFeignService {
+
+  private final ProductFeignClient productFeignClient;
+
+  @Override
+  @Retry(name = "simpleRetryConfig")
+  @CircuitBreaker(name = "simpleCircuitBreakerConfig", fallbackMethod = "fallback")
+  public void updateProductStock(UpdateQuantityByProductOptionsDto dto) {
+    productFeignClient.updateProductStock(dto);
+  }
+
+  private void fallback(UpdateQuantityByProductOptionsDto dto, ServiceUnavailable ex) {
+    Collection<ProductOptionInfo> productOptionInfos = dto.productOptionInfos();
+    for(ProductOptionInfo productOptionInfo : productOptionInfos) {
+      log.info("fallback! your request ("
+          + "productOptionId=" + productOptionInfo.getProductOptionId()
+          + "&quantity="+ productOptionInfo.getQuantity() + ")");
+    }
+    throw CustomException.from(ExceptionCode.PRODUCT_SERVICE_UNAVAILABLE);
+  }
+}

--- a/src/main/java/com/ecommerceorder/global/feign/user/UserFeignClient.java
+++ b/src/main/java/com/ecommerceorder/global/feign/user/UserFeignClient.java
@@ -2,7 +2,7 @@
  * @Date : 2024. 09. 06.
  * @author : jieun(je-pa)
  */
-package com.ecommerceorder.global.feign;
+package com.ecommerceorder.global.feign.user;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/ecommerceorder/global/feign/user/service/UserFeignService.java
+++ b/src/main/java/com/ecommerceorder/global/feign/user/service/UserFeignService.java
@@ -1,0 +1,5 @@
+package com.ecommerceorder.global.feign.user.service;
+
+public interface UserFeignService {
+  boolean existsMemberId(Long memberId);
+}

--- a/src/main/java/com/ecommerceorder/global/feign/user/service/UserFeignServiceImpl.java
+++ b/src/main/java/com/ecommerceorder/global/feign/user/service/UserFeignServiceImpl.java
@@ -1,0 +1,30 @@
+package com.ecommerceorder.global.feign.user.service;
+
+import com.ecommerceorder.global.exception.CustomException;
+import com.ecommerceorder.global.exception.ExceptionCode;
+import com.ecommerceorder.global.feign.user.UserFeignClient;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserFeignServiceImpl implements UserFeignService {
+
+  private final UserFeignClient userFeignClient;
+
+  @Override
+  @Retry(name = "simpleRetryConfig")
+  @CircuitBreaker(name = "simpleCircuitBreakerConfig", fallbackMethod = "fallback")
+  public boolean existsMemberId(Long memberId) {
+    return userFeignClient.existsMemberId(memberId);
+  }
+
+  private boolean fallback(Long memberId, Exception ex) {
+    log.info("fallback! your request is " + memberId + ":" + ex.getMessage());
+    throw CustomException.from(ExceptionCode.USER_SERVICE_UNAVAILABLE);
+  }
+}

--- a/src/main/java/com/ecommerceorder/global/scheduler/OrderScheduler.java
+++ b/src/main/java/com/ecommerceorder/global/scheduler/OrderScheduler.java
@@ -9,8 +9,8 @@ import com.ecommerceorder.domain.order.entity.OrderItem;
 import com.ecommerceorder.domain.order.repository.OrderItemRepository;
 import com.ecommerceorder.domain.order.repository.OrderRepository;
 import com.ecommerceorder.domain.order.type.OrderStatus;
-import com.ecommerceorder.global.feign.ProductFeignClient;
-import com.ecommerceorder.global.feign.dto.UpdateQuantityByProductOptionsDto;
+import com.ecommerceorder.global.feign.product.dto.UpdateQuantityByProductOptionsDto;
+import com.ecommerceorder.global.feign.product.service.ProductFeignService;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ public class OrderScheduler {
 
   private final OrderRepository orderRepository;
   private final OrderItemRepository orderItemRepository;
-  private final ProductFeignClient productFeignClient;
+  private final ProductFeignService productFeignService;
 
   @Scheduled(cron = "0 0 0 * * *") // 매일 0시에 실행
   public void processOrders() {
@@ -67,7 +67,7 @@ public class OrderScheduler {
       order.setStatus(OrderStatus.RETURNED);
       log.info("Order {} has been updated to RETURNED", order.getId());
       List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(order.getId());
-      productFeignClient.updateProductStock(UpdateQuantityByProductOptionsDto.from(orderItems));
+      productFeignService.updateProductStock(UpdateQuantityByProductOptionsDto.from(orderItems));
     }
     orderRepository.saveAll(ordersToReturn);
   }

--- a/src/test/http/order.http
+++ b/src/test/http/order.http
@@ -1,0 +1,28 @@
+###
+POST http://localhost:8083/api/v0/orders
+Content-Type: application/json
+X-Member-Id: 3
+
+[
+  {
+    "wishlistItemId": 1506
+  }
+]
+
+### 주문 생성
+POST http://localhost:8083/api/v0/orders
+X-Member-Id: 58
+Content-Type: application/json
+
+[
+  {
+    "wishlistItemId": 1511
+  }
+]
+
+###
+PATCH http://localhost:8083/api/v0/orders/1511/status
+X-Member-Id: 59
+Content-Type: application/json
+
+"CANCEL"

--- a/src/test/java/com/ecommerceorder/IntegrationTestSupport.java
+++ b/src/test/java/com/ecommerceorder/IntegrationTestSupport.java
@@ -1,7 +1,7 @@
 package com.ecommerceorder;
 
-import com.ecommerceorder.global.feign.ProductFeignClient;
-import com.ecommerceorder.global.feign.UserFeignClient;
+import com.ecommerceorder.global.feign.product.ProductFeignClient;
+import com.ecommerceorder.global.feign.user.service.UserFeignService;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
@@ -11,7 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 public abstract class IntegrationTestSupport {
 
   @MockBean
-  protected UserFeignClient userFeignClient;
+  protected UserFeignService userFeignService;
 
   @MockBean
   protected ProductFeignClient productFeignClient;

--- a/src/test/java/com/ecommerceorder/api/service/order/OrderServiceTest.java
+++ b/src/test/java/com/ecommerceorder/api/service/order/OrderServiceTest.java
@@ -7,6 +7,7 @@ package com.ecommerceorder.api.service.order;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.mockito.BDDMockito.given;
 
 import com.ecommerceorder.IntegrationTestSupport;
 import com.ecommerceorder.api.controller.ApiResponse;
@@ -87,7 +88,7 @@ class OrderServiceTest extends IntegrationTestSupport {
     WishlistItem item2  = wishlistItemRepository.save(createWishlistItem(wishlist1, option2, 2)); // member1, product1, option2
     WishlistItem item3  = wishlistItemRepository.save(createWishlistItem(wishlist2, option3, 3)); // member1, product2, option3
     wishlistItemRepository.save(createWishlistItem(wishlist2, option4, 3)); // member1, product2, option4
-
+    given(userFeignService.existsMemberId(1L)).willReturn(true);
     // when
     ApiResponse<String> result = orderService.create(new CreateOrderByWishlistItemsDto(
         List.of(

--- a/src/test/java/com/ecommerceorder/api/service/wishlist/WishlistServiceTest.java
+++ b/src/test/java/com/ecommerceorder/api/service/wishlist/WishlistServiceTest.java
@@ -259,7 +259,7 @@ class WishlistServiceTest extends IntegrationTestSupport {
     items.add(createWishlistItem(wishlist3, option5, 5)); // member2, product3, option5
     wishlistItemRepository.saveAll(items);
 
-    given(userFeignClient.existsMemberId(0L)).willReturn(false);
+    given(userFeignService.existsMemberId(0L)).willReturn(false);
     // when
     // then
     assertThatThrownBy(() -> wishlistService.modify(0L, List.of(


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #5

## 작업 내용
- feign client에 resilience4j를 활용하여 Circuit Breaker와 Retry를 붙인다.
  - 상품 재고 수량 수정 feign client에 Circuit Breaker와 Retry 적용
  - memberId 존재 유무 feign client에 Circuit Breaker와 Retry 적용

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [x] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 기타 
### 리트라이 설정
```yaml
resilience4j:
  retry:
    retry-aspect-order: 2 # 우선 순위 - 값이 높을수록 우선순위가 높아짐
    configs:
      default:
        max-attempts: 2 # 재시도 횟수
        wait-duration: 500 # 재시도 간격(총시간 = (재시도횟수 -1) * 재시도 간격
        retry-exceptions:
          - feign.FeignException.ServiceUnavailable  # 서버가 일시적으로 사용 불가능한 상태일 때 발생하는 예외
        ignore-exceptions:
          - feign.FeignException.BadGateway
          - feign.FeignException.NotImplemented
          - feign.FeignException.FeignClientException
    instances:
      simpleRetryConfig:
        baseConfig: default
```
#### 처리할 예외

`feign.FeignException.ServiceUnavailable`

- 설명: 서버가 일시적으로 사용 불가능한 상태일 때 발생하는 예외
- 이유: 서버가 일시적인 문제로 인해 응답하지 않는 경우로, 서비스가 잠시 중단되었거나 서버 부하로 인한 문제일 가능성이 크기 때문에 시간이 지나면 서버가 정상화될 수 있으므로, 재시도를 통해 요청이 성공할 가능성이 있음

#### 무시할 예외

`feign.FeignException.BadGateway`

- 설명: 서버로부터 잘못된 응답을 받았을 때 발생하는 예외 (502 상태 코드)
- 이유: 이 예외는 게이트웨이 자체의 문제를 나타내는 경우가 많고, 게이트웨이가 다른 서버와 통신하는 과정에서 오류가 발생한 것이므로, 재시도를 해도 즉각적으로 문제가 해결될 가능성이 낮아 게이트웨이 문제는 빠른 해결이 어렵거나 장기적인 문제일 수 있으므로, 재시도하지 않고 무시하는 것이 좋음

`feign.FeignException.NotImplemented`

- 설명: 클라이언트가 요청한 기능을 서버가 지원하지 않을 때 발생하는 예외 (501 상태 코드)
-이유: 서버 측에서 해당 기능이 구현되어 있지 않거나 미지원인 상태이므로 재시도를 해도 성공할 가능성이 전혀 없기 때문에 재시도할 필요가 없음

`feign.FeignException.FeignClientException`

- 설명: Feign 클라이언트의 요청이 잘못되었을 때 발생하는 예외
- 이유: 잘못된 파라미터나 비정상적인 요청 형식 때문에 발생하기 때문에 재시도를 해도 클라이언트 측의 요청이 잘못된 경우에는 성공할 가능성이 없으므로, 이를 무시하고 재시도하지 않음

### 서킷 브레이커 설정
```yaml
resilience4j:
  circuitbreaker:
    circuit-breaker-aspect-order: 1
    configs:
      default: # 설정 set (아래는 메서드들)
        sliding-window-type: COUNT_BASED
        minimum-number-of-calls: 7 # 최소 7번까지는 무조건 CLOSE로 가정하고 호출 (실제 메서드 호출은 리트라이 횟수를 곱해야함)
        sliding-window-size: 10 # (minimumNumberOfCalls 이후로는) 10개의 요청을 기준으로 판단
        wait-duration-in-open-state: 10s # OPEN 상태에서 HALF_OPEN으로 기다릴 시간

        failure-rate-threshold: 50 # slidingWindowSize 중 몇 %가 recordException이면 OPEN으로 만들 것인지

        slow-call-duration-threshold: 3000 # 몇 ms 동안 요청이 처리되지 않으면 실패로 간주
        slow-call-rate-threshold: 60 # slidingWindowSize 중 몇 %가 slowCall이면 OPEN으로 만들 것인가?

        permitted-number-of-calls-in-half-open-state: 5 # half open 상태에서 다른 상태로 전환하기 위한 판단 수(HALF_OPEN 상태에서 5번까지는 CLOSE로 가기위해 호출한다.)
        automatic-transition-from-open-to-half-open-enabled: true # OPEN 상태에서 자동으로 HALF_OPEN으로 갈 것인가?

        record-exceptions:
          - feign.FeignException.ServiceUnavailable # 서버가 일시적으로 사용 불가능한 상태일 때 발생하는 예외
          - feign.FeignException.GatewayTimeout # 서버가 게이트웨이로부터 응답을 기다리는 동안 시간이 초과된 경우 발생하는 예외
          - java.net.SocketTimeoutException
          - feign.FeignException.BadGateway # 다른 서버(게이트웨이)를 통해 잘못된 응답을 받았을 때 발생
        ignore-exceptions:
          - feign.FeignException.NotImplemented # 클라이언트의 요청을 처리할 방법을 지원하지 않는 경우 발생하는 예외
          - feign.FeignException.FeignClientException
    instances:
      simpleCircuitBreakerConfig:
        baseConfig: default
```
#### 처리할 예외

`feign.FeignException.ServiceUnavailable`

- 설명: 서버가 일시적으로 사용 불가능한 상태일 때 발생하는 예외
- 이유: 서버의 서비스가 일시적으로 중단된 경우, 해당 예외는 시스템이 해당 서버에 대한 호출을 중단하고 다른 대체 동작을 시도하도록 유도하여 서킷브레이커로 감지하여 대기 시간을 줄이고 시스템의 리소스를 보호

`feign.FeignException.GatewayTimeout`

- 설명: 클라이언트가 게이트웨이로부터 응답을 기다리는 동안 시간이 초과된 경우 발생하는 예외
- 이유: 서킷브레이커를 통해 더 이상의 시도를 막고, 일시적인 문제일 가능성이 있으므로 재시도 또는 대체 경로를 사용할 수 있도록 함

`java.net.SocketTimeoutException`

- 설명: 서버와의 소켓 연결 시 타임아웃이 발생할 때 발생하는 예외
- 이유: 소켓 연결 시 타임아웃은 일반적으로 네트워크 불안정성이나 서버 부하로 인해 발생하는 상황에서 서킷브레이커는 재시도나 대체 처리를 통해 시스템의 안정성을 유지

`feign.FeignException.BadGateway`

- 설명: 서버로부터 잘못된 응답을 받았을 때 발생하는 예외 (502 상태 코드)
- 이유: 502 Bad Gateway 오류가 자주 발생하거나, 오래 지속되는 경우에는 단순 재시도로는 해결되지 않는 문제가 있을 수 있기 때문에, 서킷브레이커를 작동시켜 해당 서비스로의 요청을 일시적으로 차단하는 것이 유리

#### 무시할 예외

`feign.FeignException.NotImplemented`

- 설명: 클라이언트가 요청한 기능을 서버가 지원하지 않을 때 발생하는 예외 (501 상태 코드)
- 이유: 서버에서 기능을 지원하지 않음을 명확하게 알린 경우이므로, 이 예외는 재시도해도 의미가 없고 다른 방법으로 요청을 처리해야 할 상황이므로 서킷브레이커를 적용할 필요가 없음

`feign.FeignException.FeignClientException`

- 설명: Feign 클라이언트의 요청이 잘못되었을 때 발생하는 예외
- 이유: 이 예외는 클라이언트 측의 오류로 인해 발생하므로, 재시도해도 성공할 가능성이 없음. 클라이언트에서 요청을 수정해야 하는 문제이므로 서킷브레이커를 적용할 필요가 없음